### PR TITLE
Add support for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The initial source is based on LinSSID 3.6. (https://sourceforge.net/projects/li
 
 ## Build Requirement
 
+### Debian/Ubuntu
+
 Install deps and build according to instruction in linssid-app/INSTALL.txt
 
 ```
@@ -39,6 +41,26 @@ sudo apt-get install -y \
 	libqt5opengl5-dev \
 	libqwt-qt5-6 \
 	libqwt-headers
+```
+
+### Fedora
+
+Install deps (no need to install weak deps):
+
+```
+sudo dnf -y --setopt=install_weak_deps=False install \
+	boost-devel \
+	qt5-qtbase-devel \
+	qt5-qtsvg-devel \
+	qwt-qt5-devel
+```
+
+Build:
+
+```
+qmake-qt5
+make
+sudo make install
 ```
 
 ## UI change

--- a/linssid-app/ViewFilterDialog.cpp
+++ b/linssid-app/ViewFilterDialog.cpp
@@ -6,6 +6,7 @@
 #include "ViewFilterDialog.h"
 #include "CustomEvent.h"
 #include "Logger.h"
+#include <QRegExpValidator>
 
 using namespace std;
 extern Logger AppLogger;

--- a/linssid-app/linssid-app.pro
+++ b/linssid-app/linssid-app.pro
@@ -22,7 +22,7 @@ INCLUDEPATH += /usr/include/boost
 INCLUDEPATH += /usr/include/qt5
 INCLUDEPATH += /usr/include/qwt
 LIBS += -lboost_regex
-LIBS += /usr/lib/libqwt-qt5.so.6
+LIBS += -lqwt-qt5
 QMAKE_CXXFLAGS += -std=c++17
 #
 TARGET = linssid
@@ -44,3 +44,5 @@ policy.path = /usr/share/polkit-1/actions
 policy.files = com.warsev.pkexec.linssid.policy
 INSTALLS += policy
 
+# Fedora-specific config
+INCLUDEPATH += /usr/include/qt5/qwt/


### PR DESCRIPTION
Hello and thanks for keeping LinSSID alive !

I recently managed to get your fork working on Fedora 34, that required some changes to the sources, so here is a PR that should allow people to build the project on Fedora without breaking the build on Debian/Ubuntu.

There seems to be a missing header in `ViewFilterDialog.cpp`, so I added it. Without the header, I have the following error:

```
g++ -c -pipe -std=c++17 -O2 -Wall -Wextra -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I. -I/usr/include/boost -I/usr/include/qt5 -I/usr/include/qwt -I/usr/include/qt5/qwt -I/usr/include/qt5/QtSvg -I/usr/include/qt5/QtWidgets -I/usr/include/qt5/QtGui -I/usr/include/qt5/QtCore -I. -I. -I/../lib64/qt5/mkspecs/linux-g++ -o build/Release/GNU-Linux-x86/ViewFilterDialog.o ViewFilterDialog.cpp
ViewFilterDialog.cpp: In member function ‘void ViewFilterDialog::initUiStates(const FilterState&)’:
ViewFilterDialog.cpp:67:46: error: expected type-specifier before ‘QRegExpValidator’
   67 |     widget.lineEditChannel->setValidator(new QRegExpValidator(QRegExp("^([0-9]{1,3})([,-]+[0-9]{1,3})*([0-9]{1,3}[,])?$"), widget.lineEditChannel));
      |                                              ^~~~~~~~~~~~~~~~
ViewFilterDialog.cpp:68:42: error: expected type-specifier before ‘QRegExpValidator’
   68 |     widget.lineEditMAC->setValidator(new QRegExpValidator(QRegExp("^([0-9A-Fa-f?]{2}[:-]){5}([0-9A-Fa-f?]{2})$"), widget.lineEditMAC));
      |                                          ^~~~~~~~~~~~~~~~
```

I also replaced `LIBS += /usr/lib/libqwt-qt5.so.6` by the more generic `LIBS += -lqwt-qt5` in the project file (in Fedora, the lib is under `/usr/lib64`, so the old line makes the build fail).

Finally, there is a need for `INCLUDEPATH += /usr/include/qt5/qwt/` because qwt headers are under that path on Fedora.